### PR TITLE
Build ELPA subdirectory as Cask itself does

### DIFF
--- a/flycheck-cask.el
+++ b/flycheck-cask.el
@@ -60,7 +60,10 @@ non-Cask projects.")
 
 (defun flycheck-cask-package-dir (root-dir)
   "Get the package directory for ROOT-DIR."
-  (expand-file-name (format ".cask/%s/elpa" emacs-version) root-dir))
+  (expand-file-name (format ".cask/%s.%s/elpa"
+                            emacs-major-version
+                            emacs-minor-version)
+                    root-dir))
 
 (defun flycheck-cask-initialize-cask-dir (directory)
   "Initialise Flycheck for the given Cask DIRECTORY."


### PR DESCRIPTION
The Cask elisp function `cask-elpa-path` builds the ELPA subdirectory [using just Emacs’s major and minor version numbers](https://github.com/cask/cask/commit/c85700d8fb3522cb3f26bc0c668c90dd451ecd5c).  So even if `emacs-version` reports `25.1.1`, Cask names the ELPA subdirectory using `25.1`, not `25.1.1`.

This mismatch was affecting the prebuilt Emacs RPMs for Fedora 24, which do indeed have `emacs-version` set to `25.1.1`.