### PR TITLE
fix emacs dependency 24.1 to 24.3 depends setq-local

### DIFF
--- a/flycheck-cask.el
+++ b/flycheck-cask.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/flycheck/flycheck-cask
 ;; Keywords: tools, convenience
 ;; Version: 0.5-cvs
-;; Package-Requires: ((emacs "24.1") (flycheck "0.14") (dash "2.4.0"))
+;; Package-Requires: ((emacs "24.3") (flycheck "0.14") (dash "2.4.0"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Hi! I found `package-lint` error, fix it.

This changes fixes below package-lint warnings
  - You should depend on (emacs "24.3") if you need
  `setq-local'. (emacs-lisp-package)