### PR TITLE
Fix byte-compiler warnings

### DIFF
--- a/flycheck-cask.el
+++ b/flycheck-cask.el
@@ -56,7 +56,9 @@ project to `flycheck-emacs-lisp-load-path'."
   "When non-nil, fall back to `package-user-dir'.
 
 When non-nil, fall back to packages from `package-user-dir' for
-non-Cask projects.")
+non-Cask projects."
+  :group 'flycheck-cask
+  :type 'directory)
 
 (defun flycheck-cask-package-dir (root-dir)
   "Get the package directory for ROOT-DIR."

--- a/flycheck-cask.el
+++ b/flycheck-cask.el
@@ -37,6 +37,7 @@
 
 (require 'flycheck)
 (require 'dash)
+(require 'package)
 
 (defgroup flycheck-cask nil
   "Cask support for Flycheck."


### PR DESCRIPTION
Hi, I install this package using Emacs-27.1.
I get some warning, I fix it.

### require package becuase reference package-user-dir

This commit solve below byte-compiler warnings
> In flycheck-cask-setup:
> flycheck-cask.el:98:58:Warning: reference to free variable
> ‘package-user-dir’

### specific customize group and type

This commit solve below byte-compiler warning
> flycheck-cask.el:57:1:Warning: defcustom for
> ‘flycheck-cask-fall-back-to-package-user-dir’ fails to specify type