### PR TITLE
Ensure Cask dir is only added once

### DIFF
--- a/flycheck-cask.el
+++ b/flycheck-cask.el
@@ -77,8 +77,8 @@ non-Cask projects."
     ;; Disable `load-path' inheritance if enabled.
     (setq-local flycheck-emacs-lisp-load-path nil))
   (when flycheck-cask-add-root-directory
-    (setq-local flycheck-emacs-lisp-load-path
-                (cons directory flycheck-emacs-lisp-load-path))))
+    (make-local-variable 'flycheck-emacs-lisp-load-path)
+    (add-to-list 'flycheck-emacs-lisp-load-path directory)))
 
 ;;;###autoload
 (defun flycheck-cask-setup ()


### PR DESCRIPTION
If you attached `flycheck-cask-setup` to `flycheck-mode-hook` like the docs suggests, toggling `flycheck-mode` will prepend the Cask directory to `flycheck-emacs-lisp-load-path` multiple times, this PR fixes this minor issue.